### PR TITLE
fix: crash on startup (#26)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-slim
+FROM node:16.5.0-alpine
 LABEL maintainer="staff@hackarmour.tech"
 
 # Specify Working Directory


### PR DESCRIPTION
per #26 

The bot will crash with `QueryCursor` under the Mongoose dependency

fixed by downgrading npm version. see for reference: Automattic/mongoose#11377

Signed-off-by: Maanas Nair <0xbirdie@gmail.com>